### PR TITLE
Cherry picks fix for circular dependency error

### DIFF
--- a/lib/paths.js
+++ b/lib/paths.js
@@ -1,6 +1,7 @@
 'use strict';
 const Hoek = require('hoek');
 const Joi = require('joi');
+const fastSafeStringify = require('fast-safe-stringify');
 
 const Parameters = require('../lib/parameters');
 const Definitions = require('../lib/definitions');
@@ -386,7 +387,7 @@ internals.overload = function (base, priority) {
  */
 internals.hasFileType = function (route) {
 
-    let routeString = JSON.stringify(route);
+    let routeString = fastSafeStringify(route);
     return routeString.indexOf('swaggerType') > -1;
 };
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {
     "boom": "^4.0.0",
+    "fast-safe-stringify": "^1.2.0",
     "handlebars": "^4.0.5",
     "hoek": "^4.0.1",
     "http-status": "^1.0.1",


### PR DESCRIPTION
Cherry picks a commit from fork's master that fixes a circular dependency issue with new versions of joi being used by fonestorm.

https://github.com/glennjones/hapi-swagger/pull/451